### PR TITLE
Add galaxy meta info

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,11 @@
+galaxy_info:
+  role_name: apache-armor
+  author: natsec
+  description: Easy way to harden your Apache webserver.
+  license: GNU General Public License v3.0
+
+  galaxy_tags:
+    - apache
+    - security
+
+dependencies: []


### PR DESCRIPTION
To allow install via Git or publishing to Galaxy meta information is now required.
